### PR TITLE
Remove 1BitSquared

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ To contribute to the list, please open a pull request(PR) to submit a server - [
 | Name        | Discord Server                     | URL                      | Description                                      |
 | ----------- | ---------------------------------- | ------------------------ | ------------------------------------------------ |
 | 0x0539.net  | https://discord.gg/n8k3cPZxe9      | N/A                      | Exploit Research                                 |
-| 1BitSquared | https://1bitsquared.com/pages/chat | https://1bitsquared.com/ | Open-source Hardware and Electrical Engineering. |
 
 ## A
 


### PR DESCRIPTION
Based on the other servers listed, our server does not fall under the "hacker" discord definition used here. Also, we were not asked if we want to be included in this list. Please remove us.