### PR TITLE
Hyperlink An Existing Link, Add Biohacker Lounge

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ To contribute to the list, please open a pull request(PR) to submit a server - [
 | BadgeMakers           | http://discord.badge.life          | N/A | Badge Life, Electronics, Buy / Sell / Trade / Learn              |
 | Bellingcat            | https://discord.gg/bellingcat      | N/A | Community for Bellingcat readers and OSINT enthusiasts           |
 | BC Security           | discord.gg/P8PZPyf                 | N/A | Threat Emulation / Training / Red Team / Pentesting / Compliance |
+| Biohacker Lounge                | https://discord.gg/Frf5VpXN9F           | https://blog.biohackinginternational.com | Main Discord in the International Biohacking Community |
 | Biohackers Digital    | https://discord.com/invite/qtnE8T3 | N/A | Biohacking Community                                             |
 | Biohacking Village    | https://discord.gg/Q8ubDb5         | N/A | Biohacking                                                       |
 | BSides Las Vegas      | https://discord.gg/JeeAjMCN        | N/A | BSides Las Vegas                                                 |

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ To contribute to the list, please open a pull request(PR) to submit a server - [
 | --------------------- | ---------------------------------- | --- | ---------------------------------------------------------------- |
 | BadgeMakers           | http://discord.badge.life          | N/A | Badge Life, Electronics, Buy / Sell / Trade / Learn              |
 | Bellingcat            | https://discord.gg/bellingcat      | N/A | Community for Bellingcat readers and OSINT enthusiasts           |
-| BC Security           | discord.gg/P8PZPyf                 | N/A | Threat Emulation / Training / Red Team / Pentesting / Compliance |
-| Biohacker Lounge                | https://discord.gg/Frf5VpXN9F           | https://blog.biohackinginternational.com | Main Discord in the International Biohacking Community |
+| BC Security           | https://discord.gg/P8PZPyf                 | N/A | Threat Emulation / Training / Red Team / Pentesting / Compliance |
+| Biohacker Lounge                | https://discord.gg/biohackers           | https://blog.biohackinginternational.com | Main Discord in the International Biohacking Community |
 | Biohackers Digital    | https://discord.com/invite/qtnE8T3 | N/A | Biohacking Community                                             |
 | Biohacking Village    | https://discord.gg/Q8ubDb5         | N/A | Biohacking                                                       |
 | BSides Las Vegas      | https://discord.gg/JeeAjMCN        | N/A | BSides Las Vegas                                                 |


### PR DESCRIPTION
**Changes**

1. Fix non-hyperlinked link for "BC Security", not currently hyperlinked.
2. Add "Biohacker Lounge", the main biohacking server in the "International Biohacking Community", 500+ members.

Thanks :)