### PR TITLE
Remove "adbs.fi" server (now airplanes.live) due to persistent spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ To contribute to the list, please open a pull request(PR) to submit a server - [
 
 | Name                    | Discord Server                          | URL                      | Description                                                                   |
 | ----------------------- | --------------------------------------- | ------------------------ | ----------------------------------------------------------------------------- |
-| adbs.fi                 | https://discord.gg/jfVRF2XRwF           | N/A                      | Community-driven flight tracker                                               |
 | Adversary Village       | https://discord.gg/rk44QhQR             | N/A                      | Adversary Village                                                             |
 | Aerospace Village       | https://discord.com/invite/gV4EWuk      | N/A                      | Aerospace Village                                                             |
 | Ai Village              | discord.gg/xMK7fuu                      | N/A                      | Artificial Intelligence Village                                               |


### PR DESCRIPTION
The airplanes.live discord server has recently been having a significant influx of users joining looking for "hacking services" or promoting "hacking related services and account recoveries/verification/cheats".

We believe that the source of these users may be from this list, and as such we would like to remove our server from here. It does not fit the list either being an aircraft tracking server, with no correlation to hacking at all. We are having to remove at least 5 users per day asking for, or promoting these kinds of services.

I'm not sure if a PR is the right way to go about this from looking at the contributing file, if it is not please let me know